### PR TITLE
Compare

### DIFF
--- a/grash/grash.c
+++ b/grash/grash.c
@@ -349,5 +349,6 @@ int main (int argc, char **argv) {
   while ((pid = wait(&status)) != -1) {
     fprintf(stderr, "%d exits %d\n", pid, WEXITSTATUS(status));
   }
+  fprintf(stderr, "GRASH DONE\n");
   exit(0);
 }

--- a/svg/compiler/Makefile
+++ b/svg/compiler/Makefile
@@ -39,8 +39,7 @@ passes :
 test-passes: passes
 	bmfbp $(SVG_DIAGRAM) >$(REGRESSION)
 	svgpasses svgc <$(SVG_DIAGRAM) >$(PASSES-REGRESSION)
-	sleep 1
-	diff -q $(PASSES-REGRESSION) $(REGRESSION)
+	$(BINDIR)/comparegsh.sh $(REGRESSION) $(PASSES-REGRESSION)
 
 clean-passes :
 	rm -f $(BINDIR)/svgpasses.gsh $(BINDIR)/scanner.gsh $(BINDIR)/parser.gsh $(BINDIR)/emitter.gsh

--- a/svg/compiler/Makefile
+++ b/svg/compiler/Makefile
@@ -10,6 +10,8 @@ dependencies:
 	cp bmfbp.sh $(BINDIR)/bmfbp
 	chmod a+x $(BINDIR)/bmfbp
 	cp svg.gsh $(BINDIR)
+	cp comparegsh.sh $(BINDIR)
+	chmod a+x $(BINDIR)/comparegsh.sh
 
 clean: clean-temps clean-passes
 	rm -f $(BINDIR)/bmfbp $(BINDIR)/svg.gsh $(REGRESSION)
@@ -20,8 +22,7 @@ clean-temps:
 
 test : dependencies
 	bmfbp $(SVG_DIAGRAM) >$(REGRESSION)
-	sleep 1
-	diff -q $(BINDIR)/svg.gsh $(REGRESSION)
+	$(BINDIR)/comparegsh.sh $(BINDIR)/svg.gsh $(REGRESSION)
 
 passes :
 	bmfbp passes.svg >$(BINDIR)/svgpasses.gsh

--- a/svg/compiler/comparegsh.sh
+++ b/svg/compiler/comparegsh.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
+sleep 1
 base1=`basename $1`
 base2=`basename $2`
 f1=/tmp/${base1}
 f2=/tmp/${base2}
 sed -e 's/Pipes.*$/Pipes/' $1 >${f1}
 sed -e 's/Pipes.*$/Pipes/' $2 >${f2}
-sleep 1
 echo
 if diff -q ${f1} ${f2}
 then echo OK

--- a/svg/compiler/comparegsh.sh
+++ b/svg/compiler/comparegsh.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+base1=`basename $1`
+base2=`basename $2`
+f1=/tmp/${base1}
+f2=/tmp/${base2}
+sed -e 's/Pipes.*$/Pipes/' $1 >${f1}
+sed -e 's/Pipes.*$/Pipes/' $2 >${f2}
+sleep 1
+echo
+if diff -q ${f1} ${f2}
+then echo OK
+else echo BAD
+fi
+echo


### PR DESCRIPTION
This change should only add "compare.gsh" and associated changes to the Makefile.  Plus a minor mod to grash.c (GRASH DONE), which is a note-to-self during construction of new compilers - we need to add a sleep 1 before cp'ing any files, or else, we might get a 0-sized intermediate file (since, the passes run in parallel and at different speeds).

It turns out that inPipes and outPipes are assigned different indices with different versions of the compilers.

This version "normalizes" the .gsh files, deleting all indices.  This should make regression testing easier. 