### PR TITLE
Fix dangling trailing parentheses

### DIFF
--- a/hs-vsh/src/Parser/DrawIO.hs
+++ b/hs-vsh/src/Parser/DrawIO.hs
@@ -74,6 +74,7 @@ collapseEmpty (Container (Empty : xs)) = collapseEmpty $ Container (map collapse
 collapseEmpty (Container (x : Empty : xs)) = Container (collapseEmpty x : map collapseEmpty xs)
 collapseEmpty (Container (Container [] : xs)) = Container $ map collapseEmpty xs
 collapseEmpty (Container [x]) = collapseEmpty x
+collapseEmpty (Container (x : Container [] : xs)) = Container (x : map collapseEmpty xs)
 collapseEmpty (Container xs) = Container $ map collapseEmpty xs
 collapseEmpty (Translate x y zs) = Translate x y $ map collapseEmpty zs
 collapseEmpty x = x


### PR DESCRIPTION
The issue in branch "probs" is now fixed. Do a `stack install` in the hs-vsh again. The trailing parentheses should be gone. However, there should be two levels of parentheses because the parser assumes this:

```
(translate (x y) (node1 node2 node3 ...))
```

Do you want me to change that as well?