### PR TITLE
Normalize namespace assumptions in test issue

### DIFF
--- a/svg/lisp-parts/issue.lisp
+++ b/svg/lisp-parts/issue.lisp
@@ -1,14 +1,12 @@
-(ql:quickload :paip-lisp)
-
+#+nil (ql:quickload :paip-lisp)
 
 (<- (p 1))
 (<- (p 2))
 (<- (p 3))
 
-
 ;; this should give three values for ?x, hitting semi-colon to generate each one
 ;; when you hit semi-colon too many times (3, I think), it answers No. (no more solutions)
-(defun test ()
+(defun cl-user::test ()
   (?- (p ?x)))
 
 


### PR DESCRIPTION
Assume that we have set a sane namespace so that basic Prolog forms
like '<-' work as expected.  Consequently, Common Lisp code for
testing needs to be explicit about namespace.

Remove references to loading from issue.

The PLOAD code below is a stab at generalizing loading.

     (in-package :cl-user)
     ;;; Initial the ability to load code in the PAIP package after loading
     ;;; its system
     (defmethod asdf:perform :after ((operation asdf:load-op)
                                     (component (eql :paip)))
       (let ((package *package*))
         (cl:setf *package* (find-package "paip"))
         (cl:unwind-protect
              (cl:load
               (asdf:system-relative-pathname :paip "lisp/prolog.lisp"))
           (cl:setf *package* package))))

     (in-package :cl-user)
     (defun pload (filename &key (package (find-package :paip)))
       (unless (probe-file filename)
         (format *standard-output* "~&No such file: ~a~%" filename)
         (return-from pload nil))
       (let ((current-package-name (package-name *package*)))
         (setf *package* (find-package package))
         (cl:unwind-protect
              (cl:load filename)
           (setf *package* (find-package current-package-name)))))