### PR TITLE
Get basic loading working under ASDF

### DIFF
--- a/svg/lisp-parts/README.md
+++ b/svg/lisp-parts/README.md
@@ -44,5 +44,7 @@ issue a
 
 then to run the simple test
 
-    (prove:run-all :arrowgram-test)
+    (prove:run :arrowgram-test)
+    
+    
 

--- a/svg/lisp-parts/README.md
+++ b/svg/lisp-parts/README.md
@@ -28,3 +28,21 @@ The shell script does a regression test, comparing results against saved files, 
 For example, the current output goes to ??/bmfbp/svg/js-compiler/lisp-out.lisp, gets munged by lisp-to-prolog and becomes temp7.pro.
 
 For now, the input and output files are hard-wired into lwpasses.lisp.  Once everything works, we'll switch to using the code in lwpasses.lisp/main() and use *standard-input* and *standard-output* again. Note that SBCL expects a different form for main() than does LW.
+
+## Dependencies
+
+### loops
+
+Try <https://github.com/guitarvydas/loops>.
+
+## Testing
+
+Using PROVE, so for the first time for every installation, one must
+issue a
+
+    (ql:quickload :arrowgram-test)
+
+then to run the simple test
+
+    (prove:run-all :arrowgram-test)
+

--- a/svg/lisp-parts/arrowgram-test.asd
+++ b/svg/lisp-parts/arrowgram-test.asd
@@ -1,0 +1,14 @@
+;;; (ql:quickload :arrowgram-test) ONCE for every installation
+(defsystem arrowgram-test
+  :defsystem-depends-on (prove-asdf)
+  :depends-on (prove
+	       arrowgram/lwpasses)
+  :pathname "t/"
+  :components ((:test-file "basic"))
+  :perform (asdf:test-op (op c)
+	      (uiop:symbol-call :prove-asdf 'run-test-system c)))
+	       
+
+
+
+

--- a/svg/lisp-parts/arrowgram.asd
+++ b/svg/lisp-parts/arrowgram.asd
@@ -1,0 +1,40 @@
+(defsystem arrowgram
+  :depends-on (paip
+	       ;; <https://github.com/guitarvydas/loops>
+	       loops)
+  :components ((:module package
+			:pathname "./"
+			:components ((:file "package")))
+	       (:module source
+			:depends-on (package)
+			:pathname "./"
+			:components ((:file "everything"))))
+  :perform (load-op :after (op c)
+	      (let ((original-package *package*))
+		(unwind-protect
+		     (progn
+		       (setf *package* (find-package :paip))
+		       (dolist (paip-requirement
+				 '("lisp/prolog.lisp"
+				   ;;; Needed for defintion of
+				   ;;; paip::replace-?-vars
+				   "lisp/krep.lisp"))
+			 (cl:load 
+			  (asdf:system-relative-pathname
+			   :paip paip-requirement))))
+		  (setf *package* original-package)))))
+		       
+
+(defsystem arrowgram/database
+  :depends-on (arrowgram)
+  :components ((:module contents
+			:pathname "./"
+			:components ((:file "assign-parents-to-ellipses")
+				     (:file "bounding-boxes"))))
+  :perform (asdf:load-op :before (op c)
+              (funcall (uiop/package:find-symbol* :clear-db :paip))))
+
+(defsystem arrowgram/lwpasses
+  :depends-on (arrowgram/database)
+  :components ((:file "lwpasses")))
+

--- a/svg/lisp-parts/loadall.lisp
+++ b/svg/lisp-parts/loadall.lisp
@@ -1,4 +1,8 @@
+;;; Deprecated in place of using arrowgram.asd
 
+
+;;; Paul:  which package is this special supposed to be in?
+;;; Doesn't seem to be present under SBCL
 (setq *handle-warn-on-redefinition* nil)
 
 (asdf:load-system :paip)

--- a/svg/lisp-parts/package.lisp
+++ b/svg/lisp-parts/package.lisp
@@ -1,0 +1,4 @@
+(defpackage :arrowgram
+  (:use :cl))
+
+

--- a/svg/lisp-parts/t/basic.lisp
+++ b/svg/lisp-parts/t/basic.lisp
@@ -1,0 +1,14 @@
+(in-package :cl-user)
+
+
+(prove:plan 1)
+
+(prove:ok
+ (progn 
+   (arrowgram::make-bounding-boxes-for-rectangles)
+   (arrowgram::make-bounding-boxes-for-text)
+   (arrowgram::make-bounding-boxes-for-speech-bubbles)
+   (arrowgram::make-bounding-boxes-for-ellipses))
+ "Testing bounding boxes.")
+
+(prove:finalize)


### PR DESCRIPTION
Include the bounding boxes test as part of a test suite, mainly to
show that we have replicated the functionality of "loadall.lisp" which
should be deprecated.