### PR TITLE
Fix typo preventing  ARROGRAM/PROLOG-PEG from compiling

### DIFF
--- a/svg/lisp-parts/prolog-peg.lisp
+++ b/svg/lisp-parts/prolog-peg.lisp
@@ -1,7 +1,7 @@
 ;(eval-when (:compile-toplevel :load-toplevel :execute)
 ;  (peg:into-package "PROLOG"))
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (peg:into-package "PAIP))
+  (peg:into-package "PAIP"))
 
 (defparameter *grammars* (list
                           *peg-rules-original*


### PR DESCRIPTION
@guitarvydas missed a closing double quote.