### PR TITLE
instead of failing, pinless issues an error message fATAL (must begin…

### DIFF
--- a/svg/parts/pinless.pl
+++ b/svg/parts/pinless.pl
@@ -16,5 +16,8 @@ check_has_port(ParentID):-
     roundedrect(ParentID),
     asserta(pinless(ParentID)).
 
+check_has_port(PID):-
+    we('fATAL: no port for id '),wen(PID).
+
 :- include('tail').
 


### PR DESCRIPTION
… with lower case due to prolog)