### PR TITLE
Add mocks for build process

### DIFF
--- a/build_process/mocks/compile_one_diagram/output.json
+++ b/build_process/mocks/compile_one_diagram/output.json
@@ -1,0 +1,61 @@
+{
+    "kindName": "default-component-name",
+    "parts": [
+        {
+            "inCount": 1,
+            "inMap": {
+                "in": 0
+            },
+            "inPins": [
+                [
+                    1
+                ]
+            ],
+            "kindName": "part",
+            "outCount": 1,
+            "outMap": {
+                "out": 0
+            },
+            "outPins": [
+                [
+                    0
+                ]
+            ],
+            "partName": "ID12"
+        },
+        {
+            "inCount": 1,
+            "inMap": {
+                "source": 0
+            },
+            "inPins": [
+                [
+                    0
+                ]
+            ],
+            "kindName": "self",
+            "outCount": 0,
+            "outMap": {},
+            "outPins": [],
+            "partName": "ID11"
+        },
+        {
+            "inCount": 0,
+            "inMap": {},
+            "inPins": [],
+            "kindName": "self",
+            "outCount": 1,
+            "outMap": {
+                "sink": 0
+            },
+            "outPins": [
+                [
+                    1
+                ]
+            ],
+            "partName": "ID8"
+        }
+    ],
+    "self": {},
+    "wireCount": 2
+}

--- a/build_process/mocks/compile_one_diagram/strings.lisp
+++ b/build_process/mocks/compile_one_diagram/strings.lisp
@@ -1,0 +1,6 @@
+(struidG0 "default-component-name")
+(struidG10 "sink")
+(struidG9 "source")
+(struidG7 "part")
+(struidG2 "in")
+(struidG1 "out")

--- a/build_process/mocks/compile_one_diagram/test.js
+++ b/build_process/mocks/compile_one_diagram/test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const compile = require('../../parts/compile_one_diagram');
+ 
+fs.readFile(`${__dirname}/facts.pro`, 'utf8', function(err, facts) {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  fs.readFile(`${__dirname}/strings.lisp`, 'utf8', function(err, strings) {
+    if (err) {
+      console.error(err);
+      return;
+    }
+
+    compile.main('name', 'test-name', send);
+    compile.main('facts', facts, send);
+    compile.main('strings', strings, send);
+  });
+});
+
+function send(pin, packet) {
+  switch (pin) {
+    case 'graph as json':
+      console.log('output: ', packet);
+      break;
+  }
+}

--- a/build_process/parts/compile_one_diagram.js
+++ b/build_process/parts/compile_one_diagram.js
@@ -1,31 +1,82 @@
 const child_process = require('child_process');
 const fs = require('fs');
-const temp = require('../lib/temp');
+const os = require('os');
+const { sep } = require('path');
 
 // This is assumed to be on PATH.
 const program = 'part_compile';
 
+var params = {};
+
 exports.main = (pin, packet, send) => {
   switch (pin) {
-    case 'diagram':
-      temp.file((inputFilePath) => {
-        fs.writeFile(inputFilePath, packet, (err) => {
-          if (err) {
-            console.error(err);
-            return;
-          }
-
-          const command = [program, inputFilePath].join(' ');
-          child_process.exec(command, function(err, stdout, stderr) {
-            if (err) {
-              console.error(err);
-              return;
-            }
-
-            send('graph as json', stdout);
-          });
-        });
-      });
+    case 'name':
+      params.name = packet;
+      compile(send);
+      break;
+    case 'facts':
+      params.facts = packet;
+      compile(send);
+      break;
+    case 'strings':
+      params.strings = packet;
+      compile(send);
       break;
   }
 };
+
+async function writeTempFile(filePath, content) {
+  return new Promise((resolve, reject) => {
+    fs.writeFile(filePath, content, (err) => {
+      if (err) {
+        console.error(filePath, err);
+        reject();
+        return;
+      }
+
+      resolve(filePath);
+    });
+  });
+}
+
+function compile(send) {
+  compile2(send).catch(err => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+  });
+}
+
+async function compile2(send) {
+  if (!params.name || !params.facts || !params.strings) {
+    return;
+  }
+  const name = params.name;
+  const facts = params.facts;
+  const strings = params.strings;
+
+  await fs.mkdtemp(`${os.tmpdir()}${sep}`, async (err, dir) => {
+    if (err) {
+      console.error(dir, err);
+      return;
+    }
+
+    const factPath = await writeTempFile(dir + "facts", facts);
+    const stringPath = await writeTempFile(dir + "strings" , strings);
+    const command = [program, name, stringPath, factPath].join(' ');
+
+    child_process.exec(command, function(err, stdout, stderr) {
+      console.error(stderr);
+      if (err) {
+        console.error(command, err);
+        return;
+      }
+
+      send('graph as json', stdout);
+    });
+  });
+
+  // Clean up
+  params = {};
+}

--- a/svg/js-compiler/Makefile
+++ b/svg/js-compiler/Makefile
@@ -12,6 +12,8 @@ dependencies:
 	chmod a+x $(BINDIR)/jsbmfbp
 	cp ./jsbmfbp2.sh $(BINDIR)/jsbmfbp2
 	chmod a+x $(BINDIR)/jsbmfbp2
+	cp ./jsbmfbp3.sh $(BINDIR)/jsbmfbp3
+	chmod a+x $(BINDIR)/jsbmfbp3
 	cp ./part_compile.sh $(BINDIR)/part_compile
 	chmod a+x $(BINDIR)/part_compile
 	cp ./compare-graph.sh $(BINDIR)/compare-graph

--- a/svg/js-compiler/jsbmfbp3.sh
+++ b/svg/js-compiler/jsbmfbp3.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+NAME="$1"
+STRINGS_FILE_PATH="$2"
+FACTS_FILE_PATH="$3"
+
+# Force this file to run in the same directory as the file.
+#cd "$( dirname "${BASH_SOURCE[0]}" )"
+#cd /tmp
+
+if [ -z $NAME ]; then
+  >&2 echo "Missing name"
+  exit 3
+fi
+if [ -z $STRINGS_FILE_PATH ]; then
+  >&2 echo "Missing strings file"
+  exit 4
+fi
+if [ -z $FACTS_FILE_PATH ]; then
+  >&2 echo "Missing facts file"
+  exit 5
+fi
+
+# Use provided string map file
+cat $STRINGS_FILE_PATH >temp-string-map.lisp
+
+# parser
+assign_parents_to_ellipses <$FACTS_FILE_PATH >temp6.pro
+find_comments $NAME <temp6.pro >temp7.pro
+find_metadata $NAME <temp7.pro >temp8.pro
+add_kinds $NAME <temp8.pro >temp9.pro
+add_selfPorts $NAME <temp9.pro >temp10.pro
+make_unknown_port_names $NAME <temp10.pro >temp11.pro
+create_centers $NAME <temp11.pro >temp12.pro
+calculate_distances $NAME <temp12.pro >temp13.pro
+assign_portnames $NAME <temp13.pro >temp14.pro
+markIndexedPorts $NAME <temp14.pro >temp15.pro
+coincidentPorts $NAME <temp15.pro >temp16.pro
+mark_directions $NAME <temp16.pro >temp17.pro
+match_ports_to_components <temp17.pro >temp18a.pro
+pinless <temp18a.pro >temp18.pro
+
+# semantics
+sem_partsHaveSomePorts <temp18.pro >temp19.pro
+sem_portsHaveSinkOrSource <temp19.pro >temp20a.pro
+sem_noDuplicateKinds <temp20a.pro >temp20b.pro
+sem_speechVScomments <temp20b.pro >temp20.pro
+
+# emitter
+assign_wire_numbers_to_edges $NAME <temp20.pro >temp21.pro
+selfInputPins <temp21.pro >temp22a.pro
+selfOutputPins <temp22a.pro >temp22b.pro
+inputPins <temp22b.pro >temp22c.pro
+outputPins <temp22c.pro >temp22.pro
+
+
+loginfo <temp22.pro >temp25.pro
+dumplog <temp25.pro 2>temp.log-unfixed.txt
+
+if grep -q 'ATAL' temp.log-unfixed.txt ; then
+    cat temp.log-unfixed.txt
+    echo QUIT
+    exit 1
+else    
+    new_emit_js $NAME <temp25.pro >temp26.lisp
+    unmap-strings $NAME <temp26.lisp >temp27.lisp
+    new_emit_js2 $NAME <temp27.lisp >temp28.json
+    #sed -f strings.sed <temp.log-unfixed.txt >temp.log.txt
+fi

--- a/svg/js-compiler/part_compile.sh
+++ b/svg/js-compiler/part_compile.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-jsbmfbp $1
+jsbmfbp3 "$@"
+[ $? -gt 0 ] && >&2 echo "jsbmfbp failed" && exit 3
 cat temp28.json


### PR DESCRIPTION
@easye 

This PR contains the mock for `compile_one_composite`, which is what runs the compiler.

Instructions:

1. Make the compiler first
2. Run `node mocks/compile_one_diagram/test.js` in the `build_process` directory.

`output.json` is the expected output.

The output is a JSON file that contains all the wiring information.

I'll work on the rest of the diagrams, but I want to check in with you on whether this is what you've expected first.

# Actions

- [ ] Encode this in `.travis.yml`